### PR TITLE
block txs

### DIFF
--- a/models/bronze/streamline/core/bronze__FR_blocks.sql
+++ b/models/bronze/streamline/core/bronze__FR_blocks.sql
@@ -6,7 +6,7 @@
 {{ streamline_external_table_FR_query_v2(
     model,
     partition_function = "CAST(SPLIT_PART(SPLIT_PART(file_name, '/', 3), '_', 1) AS INTEGER)",
-    partition_name = "_partition_by_block_id",
+    partition_name = "partition_key",
     unique_key = "block_id",
     other_cols="data:error::variant AS error"
 ) }}

--- a/models/bronze/streamline/core/bronze__FR_transactions.sql
+++ b/models/bronze/streamline/core/bronze__FR_transactions.sql
@@ -6,7 +6,7 @@
 {{ streamline_external_table_FR_query_v2(
     model,
     partition_function = "CAST(SPLIT_PART(SPLIT_PART(file_name, '/', 3), '_', 1) AS INTEGER)",
-    partition_name = "_partition_by_block_id",
+    partition_name = "partition_key",
     unique_key = "block_id",
     other_cols="data:error::variant AS error, data:transaction:signatures[0]::string AS tx_id, value:array_index AS index"
 ) }}

--- a/models/bronze/streamline/core/bronze__FR_transactions.sql
+++ b/models/bronze/streamline/core/bronze__FR_transactions.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "block_txs" %}
+{{ streamline_external_table_FR_query_v2(
+    model,
+    partition_function = "CAST(SPLIT_PART(SPLIT_PART(file_name, '/', 3), '_', 1) AS INTEGER)",
+    partition_name = "_partition_by_block_id",
+    unique_key = "block_id",
+    other_cols="data:error::variant AS error, data:transaction:signatures[0]::string AS tx_id, value:array_index AS index"
+) }}

--- a/models/bronze/streamline/core/bronze__blocks.sql
+++ b/models/bronze/streamline/core/bronze__blocks.sql
@@ -6,7 +6,7 @@
 {{ streamline_external_table_query_v2(
     model,
     partition_function = "CAST(SPLIT_PART(SPLIT_PART(file_name, '/', 3), '_', 1) AS INTEGER)",
-    partition_name = "_partition_by_block_id",
+    partition_name = "partition_key",
     unique_key = "block_id",
     other_cols="data:error::variant AS error"
 ) }}

--- a/models/bronze/streamline/core/bronze__transactions.sql
+++ b/models/bronze/streamline/core/bronze__transactions.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "block_txs" %}
+{{ streamline_external_table_query_v2(
+    model,
+    partition_function = "CAST(SPLIT_PART(SPLIT_PART(file_name, '/', 3), '_', 1) AS INTEGER)",
+    partition_name = "_partition_by_block_id",
+    unique_key = "block_id",
+    other_cols="data:error::variant AS error, data:transaction:signatures[0]::string AS tx_id, value:array_index AS index"
+) }}

--- a/models/bronze/streamline/core/bronze__transactions.sql
+++ b/models/bronze/streamline/core/bronze__transactions.sql
@@ -6,7 +6,7 @@
 {{ streamline_external_table_query_v2(
     model,
     partition_function = "CAST(SPLIT_PART(SPLIT_PART(file_name, '/', 3), '_', 1) AS INTEGER)",
-    partition_name = "_partition_by_block_id",
+    partition_name = "partition_key",
     unique_key = "block_id",
     other_cols="data:error::variant AS error, data:transaction:signatures[0]::string AS tx_id, value:array_index AS index"
 ) }}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -6,6 +6,7 @@ sources:
     schema: "{{ 'eclipse' if target.database == 'ECLIPSE' else 'eclipse_dev' }}"
     tables:
       - name: blocks
+      - name: block_txs
   - name: crosschain
     database: "{{ 'crosschain' if target.database == 'ECLIPSE' else 'crosschain_dev' }}"
     schema: core

--- a/models/streamline/core/complete/streamline__block_txs_complete.sql
+++ b/models/streamline/core/complete/streamline__block_txs_complete.sql
@@ -1,0 +1,33 @@
+-- depends_on: {{ ref('bronze__transactions') }}
+-- depends_on: {{ ref('bronze__FR_transactions') }}
+
+{{ config (
+    materialized = "incremental",
+    unique_key = 'block_id',
+    merge_exclude_columns = ["inserted_timestamp"],
+    cluster_by = "ROUND(block_id, -5)",
+) }}
+
+SELECT
+    block_id,
+    error,
+    _partition_by_block_id,
+    _inserted_timestamp,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id,
+FROM
+{% if is_incremental() %}
+    {{ ref('bronze__transactions') }}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            COALESCE(MAX(_INSERTED_TIMESTAMP), '1970-01-01' :: DATE) max_INSERTED_TIMESTAMP
+        FROM
+            {{ this }}
+    )
+{% else %}
+    {{ ref('bronze__FR_transactions') }}
+{% endif %}
+QUALIFY
+    row_number() OVER (PARTITION BY block_id ORDER BY _inserted_timestamp DESC) = 1

--- a/models/streamline/core/complete/streamline__block_txs_complete.sql
+++ b/models/streamline/core/complete/streamline__block_txs_complete.sql
@@ -11,7 +11,7 @@
 SELECT
     block_id,
     error,
-    _partition_by_block_id,
+    partition_key,
     _inserted_timestamp,
     sysdate() AS inserted_timestamp,
     sysdate() AS modified_timestamp,

--- a/models/streamline/core/complete/streamline__blocks_complete.sql
+++ b/models/streamline/core/complete/streamline__blocks_complete.sql
@@ -11,7 +11,7 @@
 SELECT
     block_id,
     error,
-    _partition_by_block_id,
+    partition_key,
     _inserted_timestamp,
     sysdate() AS inserted_timestamp,
     sysdate() AS modified_timestamp,

--- a/models/streamline/core/realtime/streamline__block_txs_realtime.sql
+++ b/models/streamline/core/realtime/streamline__block_txs_realtime.sql
@@ -1,0 +1,78 @@
+  -- depends_on: {{ ref('streamline__node_min_block_available') }}
+{{ config (
+    materialized = "view",
+    post_hook = fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_rest_api_v2',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"block_txs",
+        "sql_limit" :"100000",
+        "producer_batch_size" :"100000",
+        "worker_batch_size" :"20000",
+        "sql_source" :"{{this.identifier}}",
+        "order_by_column": "block_id",
+        "exploded_key": tojson(["result.transactions"]) }
+    )
+) }}
+
+{% if execute %}
+    {% set min_block_query %}
+    SELECT min(block_id) FROM {{ ref('streamline__node_min_block_available') }}
+    {% endset %}
+
+    {% set min_block_id = run_query(min_block_query)[0][0] %}
+{% endif %}
+
+WITH blocks AS (
+    SELECT
+        block_id
+    FROM
+        {{ ref("streamline__blocks") }}
+    WHERE
+        /* Find the earliest block available from the node provider */
+        block_id >= {{ min_block_id }}
+    EXCEPT
+    SELECT
+        block_id
+    FROM
+        {{ ref('streamline__block_txs_complete') }}
+)
+SELECT
+    block_id,
+    ROUND(
+        block_id,
+        -5
+    ) :: INT AS partition_key,
+    {{ target.database }}.live.udf_api(
+        'POST',
+        'https://mainnetbeta-rpc.eclipse.xyz',
+        OBJECT_CONSTRUCT(
+            'Content-Type',
+            'application/json'
+        ),
+        OBJECT_CONSTRUCT(
+            'id',
+            block_id,
+            'jsonrpc',
+            '2.0',
+            'method',
+            'getBlock',
+            'params',
+            ARRAY_CONSTRUCT(
+                block_id,
+                OBJECT_CONSTRUCT(
+                    'encoding',
+                    'jsonParsed',
+                    'rewards',
+                    False,
+                    'transactionDetails',
+                    'full',
+                    'maxSupportedTransactionVersion',
+                    0
+                )
+            )
+        )
+    ) AS request
+FROM
+    blocks
+ORDER BY
+    block_id


### PR DESCRIPTION
- Add models to get raw block txs from streamline

Tested on dev
```
16:36:37  1 of 2 OK created sql incremental model streamline.block_txs_complete .......... [SUCCESS 10657 in 6.43s]
16:36:37  2 of 2 START sql view model streamline.block_txs_realtime ...................... [RUN]
16:36:37  Running macro `if_data_call_function`: Calling udf streamline.udf_bulk_rest_api_v2 with params: 
{
  "exploded_key": "[\"result.transactions\"]",
  "external_table": "block_txs",
  "order_by_column": "block_id",
  "producer_batch_size": "100000",
  "sql_limit": "100000",
  "sql_source": "{{this.identifier}}",
  "worker_batch_size": "20000"
}
 on {{this.schema}}.{{this.identifier}}
16:36:49  2 of 2 OK created sql view model streamline.block_txs_realtime ................. [SUCCESS 1 in 12.00s]
```

```
select 
    *
from eclipse_dev.bronze.transactions
```