### PR TITLE
Silver votes

### DIFF
--- a/models/descriptions/vote_account.md
+++ b/models/descriptions/vote_account.md
@@ -1,0 +1,5 @@
+{% docs vote_account %}
+
+Account belonging to the voting delegator
+
+{% enddocs %}

--- a/models/descriptions/vote_authority.md
+++ b/models/descriptions/vote_authority.md
@@ -1,0 +1,5 @@
+{% docs vote_authority %}
+
+Authority for the voting delegator
+
+{% enddocs %}

--- a/models/descriptions/vote_index.md
+++ b/models/descriptions/vote_index.md
@@ -1,0 +1,5 @@
+{% docs vote_index %}
+
+Index of the vote within a transaction
+
+{% enddocs %}

--- a/models/descriptions/vote_state_update.md
+++ b/models/descriptions/vote_state_update.md
@@ -1,0 +1,5 @@
+{% docs vote_state_update %}
+
+JSON data for the vote state upsdate
+
+{% enddocs %}

--- a/models/silver/core/silver__votes.sql
+++ b/models/silver/core/silver__votes.sql
@@ -1,0 +1,129 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['tx_id','vote_index'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE','block_id','_inserted_timestamp::DATE'],
+    merge_exclude_columns = ["inserted_timestamp"],
+    tags = ['scheduled_core']
+) }}
+
+{% if execute %}
+    {% if is_incremental() %}
+    {% set max_inserted_query %}
+    SELECT
+        MAX(_inserted_timestamp) AS _inserted_timestamp
+    FROM
+        {{ this }}
+    {% endset %}
+    {% set max_inserted_timestamp = run_query(max_inserted_query)[0][0] %}
+    {% endif %}
+{% endif %}
+
+WITH pre_final AS (
+    SELECT
+        b.block_timestamp AS block_timestamp,
+        t.block_id,
+        t.tx_id,
+        t.index,
+        t.data:transaction:message:recentBlockhash::string AS recent_block_hash,
+        t.data:meta:fee::number AS fee,
+        CASE
+            WHEN is_null_value(t.data:meta:err) THEN 
+                TRUE
+            ELSE 
+                FALSE
+        END AS succeeded,
+        t.data:transaction:message:accountKeys::array AS account_keys,
+        i.index::int AS vote_index,
+        i.value:parsed:info:voteAccount::string AS vote_account,
+        i.value:parsed:info:voteAuthority::string AS vote_authority,
+        i.value:parsed:info:voteStateUpdate::variant AS vote_state_update,
+        t.data:version::string as version,
+        t.partition_key,
+        t._inserted_timestamp
+    FROM
+        {{ ref('bronze__transactions') }} t
+    LEFT OUTER JOIN 
+        {{ ref('silver__blocks') }} b
+        ON b.block_id = t.block_id
+    JOIN
+        table(flatten(t.data:transaction:message:instructions)) i
+    WHERE
+        tx_id IS NOT NULL
+        AND coalesce(t.data:transaction:message:instructions[0]:programId::string,'') = 'Vote111111111111111111111111111111111111111'
+        AND i.value:programId::string = 'Vote111111111111111111111111111111111111111'
+        {% if is_incremental() %}
+        AND t._inserted_timestamp >= '{{ max_inserted_timestamp }}'
+        {% else %}
+        AND t._inserted_timestamp::date = '2024-08-30' /* TODO replace with whenever we start getting data in PROD */
+        {% endif %}
+)
+{% if is_incremental() %}
+,
+prev_null_block_timestamp_txs AS (
+    SELECT
+        b.block_timestamp,
+        t.block_id,
+        t.tx_id,
+        t.index,
+        t.recent_block_hash,
+        t.signers,
+        t.fee,
+        t.succeeded,
+        t.account_keys,
+        t.vote_index,
+        t.vote_account,
+        t.vote_authority,
+        t.vote_state_update,
+        t.version,
+        t.partition_key,
+        greatest(t._inserted_timestamp,b._inserted_timestamp) as _inserted_timestamp
+    FROM
+        {{ this }} t
+    INNER JOIN 
+        {{ ref('silver__blocks') }} b
+        ON b.block_id = t.block_id
+    WHERE
+        t.block_timestamp::DATE IS NULL
+)
+{% endif %}
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    index,
+    recent_block_hash,
+    silver.udf_ordered_signers(account_keys) AS signers,
+    fee,
+    succeeded,
+    account_keys,
+    vote_index,
+    vote_account,
+    vote_authority,
+    vote_state_update,
+    version,
+    partition_key,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_id', 'vote_index']
+    ) }} AS transactions_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    pre_final b 
+QUALIFY
+    row_number() OVER (PARTITION BY block_id, tx_id ORDER BY _inserted_timestamp DESC) = 1
+{% if is_incremental() %}
+UNION
+SELECT
+    *,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_id', 'vote_index']
+    ) }} AS transactions_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    prev_null_block_timestamp_txs
+{% endif %}

--- a/models/silver/core/silver__votes.sql
+++ b/models/silver/core/silver__votes.sql
@@ -106,7 +106,7 @@ SELECT
     _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(
         ['tx_id', 'vote_index']
-    ) }} AS transactions_id,
+    ) }} AS votes_id,
     sysdate() AS inserted_timestamp,
     sysdate() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id
@@ -120,7 +120,7 @@ SELECT
     *,
     {{ dbt_utils.generate_surrogate_key(
         ['tx_id', 'vote_index']
-    ) }} AS transactions_id,
+    ) }} AS votes_id,
     sysdate() AS inserted_timestamp,
     sysdate() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id

--- a/models/silver/core/silver__votes.sql
+++ b/models/silver/core/silver__votes.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     unique_key = ['tx_id','vote_index'],
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
-    cluster_by = ['block_timestamp::DATE','block_id','_inserted_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['scheduled_core']
 ) }}

--- a/models/silver/core/silver__votes.yml
+++ b/models/silver/core/silver__votes.yml
@@ -1,0 +1,87 @@
+version: 2
+models:
+  - name: silver__votes
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: RECENT_BLOCK_HASH
+        description: Previous block's hash value
+        tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null: *recent_date_filter
+          - unique:
+              config:
+                where: >
+                  block_timestamp::date > current_date - 30
+      - name: INDEX
+        description: "{{ doc('tx_index') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: FEE
+        description: Transaction fee (in lamports)
+        tests: 
+          - not_null: *recent_date_filter
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: SIGNERS
+        description: List of accounts that signed the transaction
+      - name: ACCOUNT_KEYS
+        description: List of accounts that are referenced by pre/post sol/token balances objects
+        tests: 
+          - not_null: *recent_date_filter
+      - name: VOTE_INDEX
+        description: Index of the vote within a transaction
+        tests:
+          - not_null: *recent_date_filter
+      - name: VOTE_ACCOUNT
+        description: Account belonging to the voting delegator
+        tests: 
+          - not_null: *recent_date_filter
+      - name: VOTE_AUTHORITY
+        description: Authority for the voting delegator
+        tests: 
+          - not_null: *recent_date_filter
+      - name: VOTE_STATE_UPDATE
+        description: JSON data for the vote state upsdate
+        tests: 
+          - not_null: *recent_date_filter
+      - name: VERSION
+        description: Transaction version, legacy version is listed as NULL or 'legacy'
+      - name: PARTITION_KEY
+        description: Partition used by the upstream bronze model
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: TRANSACTIONS_ID
+        description: '{{ doc("pk") }}'
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null_votes__invocation_id
+              <<: *recent_date_filter

--- a/models/silver/core/silver__votes.yml
+++ b/models/silver/core/silver__votes.yml
@@ -67,7 +67,7 @@ models:
         description: "{{ doc('_inserted_timestamp') }}"
         data_tests: 
           - not_null: *recent_date_filter
-      - name: TRANSACTIONS_ID
+      - name: VOTES_ID
         description: '{{ doc("pk") }}'
         data_tests: 
           - not_null: *recent_date_filter

--- a/models/silver/core/silver__votes.yml
+++ b/models/silver/core/silver__votes.yml
@@ -38,31 +38,31 @@ models:
         tests: 
           - not_null: *recent_date_filter
       - name: SIGNERS
-        description: List of accounts that signed the transaction
+        description: "{{ doc('signers') }}"
       - name: ACCOUNT_KEYS
-        description: List of accounts that are referenced by pre/post sol/token balances objects
+        description: "{{ doc('tx_account_keys') }}"
         tests: 
           - not_null: *recent_date_filter
       - name: VOTE_INDEX
-        description: Index of the vote within a transaction
+        description: "{{ doc('vote_index') }}"
         tests:
           - not_null: *recent_date_filter
       - name: VOTE_ACCOUNT
-        description: Account belonging to the voting delegator
+        description: "{{ doc('vote_account') }}"
         tests: 
           - not_null: *recent_date_filter
       - name: VOTE_AUTHORITY
-        description: Authority for the voting delegator
+        description: "{{ doc('vote_authority') }}"
         tests: 
           - not_null: *recent_date_filter
       - name: VOTE_STATE_UPDATE
-        description: JSON data for the vote state upsdate
+        description: "{{ doc('vote_state_update') }}"
         tests: 
           - not_null: *recent_date_filter
       - name: VERSION
-        description: Transaction version, legacy version is listed as NULL or 'legacy'
+        description: "{{ doc('tx_version') }}"
       - name: PARTITION_KEY
-        description: Partition used by the upstream bronze model
+        description: "{{ doc('partition_key') }}"
       - name: _INSERTED_TIMESTAMP
         description: "{{ doc('_inserted_timestamp') }}"
         data_tests: 
@@ -83,5 +83,5 @@ models:
         description: '{{ doc("_invocation_id") }}' 
         data_tests: 
           - not_null:
-              name: test_silver__not_null_votes__invocation_id
+              name: test_silver__not_null_votes_invocation_id
               <<: *recent_date_filter


### PR DESCRIPTION
- Add `silver.votes`
  - Include `vote_state_update` as a json column
  - Now includes `index` to indicate execution order within a given block
  - Now includes `vote_index` to indicate execution order within a given transaction
  
Incremental and tests on M
```
dbt build -s models/silver/core/silver__votes.sql -t dev
16:27:24  Finished running 1 incremental model, 18 data tests, 5 project hooks in 0 hours 1 minutes and 41.46 seconds (101.46s).
16:27:24  
16:27:24  Completed successfully
16:27:24  
16:27:24  Done. PASS=19 WARN=0 ERROR=0 SKIP=0 TOTAL=19
```