### PR TITLE
Silver internal

### DIFF
--- a/models/descriptions/account_index.md
+++ b/models/descriptions/account_index.md
@@ -1,0 +1,5 @@
+{% docs account_index %}
+
+Location corresponding to the index in the transaction's account keys array
+
+{% enddocs %}

--- a/models/descriptions/decimal.md
+++ b/models/descriptions/decimal.md
@@ -1,0 +1,5 @@
+{% docs decimal %}
+
+Number of decimals in the token value, need to divide amount by 10^decimal
+
+{% enddocs %}

--- a/models/descriptions/mint.md
+++ b/models/descriptions/mint.md
@@ -1,0 +1,5 @@
+{% docs mint %}
+
+Address of the token or NFT
+
+{% enddocs %}

--- a/models/descriptions/token_balances_index.md
+++ b/models/descriptions/token_balances_index.md
@@ -1,0 +1,5 @@
+{% docs token_balances_index %}
+
+Location of the token balance entry within the array for a transaction
+
+{% enddocs %}

--- a/models/descriptions/token_owner.md
+++ b/models/descriptions/token_owner.md
@@ -1,0 +1,5 @@
+{% docs token_owner %}
+
+Address of the owner of the token account
+
+{% enddocs %}

--- a/models/descriptions/ui_amount.md
+++ b/models/descriptions/ui_amount.md
@@ -1,0 +1,5 @@
+{% docs ui_amount %}
+
+Decimal adjusted amount of the token
+
+{% enddocs %}

--- a/models/silver/core/silver___post_token_balances.sql
+++ b/models/silver/core/silver___post_token_balances.sql
@@ -23,7 +23,7 @@ SELECT
     _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(
         ['block_id','tx_id','b.index']
-    ) }} AS _post_token_balance_id,
+    ) }} AS _post_token_balances_id,
     sysdate() AS inserted_timestamp,
     sysdate() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id

--- a/models/silver/core/silver___post_token_balances.sql
+++ b/models/silver/core/silver___post_token_balances.sql
@@ -1,0 +1,44 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['block_id','tx_id','index'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
+    tags = ['scheduled_core']
+) }}
+
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    b.index,
+    b.value:accountIndex::integer AS account_index,
+    t.account_keys[account_index]:pubkey::string AS account,
+    b.value:mint::string AS mint,
+    b.value:owner::string AS owner,
+    b.value:uiTokenAmount:amount::integer AS amount,
+    b.value:uiTokenAmount:decimals AS decimal,
+    coalesce(b.value:uiTokenAmount:uiAmount::float,0) AS ui_amount,
+    b.value:uiTokenAmount:uiAmountString::string AS ui_amount_string,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['block_id','tx_id','b.index']
+    ) }} AS _post_token_balance_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    {{ ref('silver__transactions') }} t,
+    table(flatten(post_token_balances)) b
+{% if is_incremental() %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp)
+        FROM
+            {{ this }}
+    )
+{% else %}
+WHERE
+    _inserted_timestamp::date = '2024-08-30' /* TODO replace with whenever we start getting data in PROD */
+{% endif %}

--- a/models/silver/core/silver___post_token_balances.yml
+++ b/models/silver/core/silver___post_token_balances.yml
@@ -1,0 +1,82 @@
+version: 2
+models:
+  - name: silver___post_token_balances
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+          where: block_timestamp::date > current_date - 30
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('token_balances_index') }}"
+        tests: 
+          - not_null: *recent_date_filter 
+      - name: ACCOUNT_INDEX
+        description: "{{ doc('account_index') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: MINT
+        description: "{{ doc('mint') }}"
+        tests: 
+          - not_null: *recent_date_filter 
+      - name: OWNER
+        description: "{{ doc('token_owner') }}" 
+        tests: 
+          - not_null: *recent_date_filter
+      - name: DECIMAL 
+        description: "{{ doc('decimal') }}" 
+        tests: 
+          - not_null: *recent_date_filter 
+      - name: UI_AMOUNT
+        description: "{{ doc('ui_amount') }}" 
+        tests: 
+          - not_null: *recent_date_filter
+      - name: UI_AMOUNT_STRING
+        description: "{{ doc('ui_amount') }} as a string" 
+        tests: 
+          - not_null: *recent_date_filter  
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _POST_TOKEN_BALANCE_ID
+        description: '{{ doc("pk") }}'
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null_post_token_balances_pk
+              <<: *recent_date_filter
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null__post_token_balances_invocation_id
+              <<: *recent_date_filter

--- a/models/silver/core/silver___post_token_balances.yml
+++ b/models/silver/core/silver___post_token_balances.yml
@@ -59,7 +59,7 @@ models:
         description: "{{ doc('_inserted_timestamp') }}"
         data_tests: 
           - not_null: *recent_date_filter
-      - name: _POST_TOKEN_BALANCE_ID
+      - name: _POST_TOKEN_BALANCES_ID
         description: '{{ doc("pk") }}'
         data_tests: 
           - not_null:

--- a/models/silver/core/silver___pre_token_balances.sql
+++ b/models/silver/core/silver___pre_token_balances.sql
@@ -1,0 +1,44 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['block_id','tx_id','index'],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
+    tags = ['scheduled_core']
+) }}
+
+SELECT
+    block_timestamp,
+    block_id,
+    tx_id,
+    succeeded,
+    b.index,
+    b.value:accountIndex::integer AS account_index,
+    t.account_keys[account_index]:pubkey::string AS account,
+    b.value:mint::string AS mint,
+    b.value:owner::string AS owner,
+    b.value:uiTokenAmount:amount::integer AS amount,
+    b.value:uiTokenAmount:decimals AS decimal,
+    coalesce(b.value:uiTokenAmount:uiAmount::float,0) AS ui_amount,
+    b.value:uiTokenAmount:uiAmountString::string AS ui_amount_string,
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['block_id','tx_id','b.index']
+    ) }} AS _pre_token_balance_id,
+    sysdate() AS inserted_timestamp,
+    sysdate() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    {{ ref('silver__transactions') }} t,
+    table(flatten(pre_token_balances)) b
+{% if is_incremental() %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp)
+        FROM
+            {{ this }}
+    )
+{% else %}
+WHERE
+    _inserted_timestamp::date = '2024-08-30' /* TODO replace with whenever we start getting data in PROD */
+{% endif %}

--- a/models/silver/core/silver___pre_token_balances.sql
+++ b/models/silver/core/silver___pre_token_balances.sql
@@ -23,7 +23,7 @@ SELECT
     _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(
         ['block_id','tx_id','b.index']
-    ) }} AS _pre_token_balance_id,
+    ) }} AS _pre_token_balances_id,
     sysdate() AS inserted_timestamp,
     sysdate() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id

--- a/models/silver/core/silver___pre_token_balances.yml
+++ b/models/silver/core/silver___pre_token_balances.yml
@@ -1,0 +1,82 @@
+version: 2
+models:
+  - name: silver___pre_token_balances
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - INDEX
+          where: block_timestamp::date > current_date - 30
+    columns:
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null: *recent_date_filter
+      - name: SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: INDEX
+        description: "{{ doc('token_balances_index') }}"
+        tests: 
+          - not_null: *recent_date_filter 
+      - name: ACCOUNT_INDEX
+        description: "{{ doc('account_index') }}"
+        tests: 
+          - not_null: *recent_date_filter
+      - name: MINT
+        description: "{{ doc('mint') }}"
+        tests: 
+          - not_null: *recent_date_filter 
+      - name: OWNER
+        description: "{{ doc('token_owner') }}" 
+        tests: 
+          - not_null: *recent_date_filter
+      - name: DECIMAL 
+        description: "{{ doc('decimal') }}" 
+        tests: 
+          - not_null: *recent_date_filter 
+      - name: UI_AMOUNT
+        description: "{{ doc('ui_amount') }}" 
+        tests: 
+          - not_null: *recent_date_filter
+      - name: UI_AMOUNT_STRING
+        description: "{{ doc('ui_amount') }} as a string" 
+        tests: 
+          - not_null: *recent_date_filter  
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _PRE_TOKEN_BALANCE_ID
+        description: '{{ doc("pk") }}'
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null_pre_token_balances_pk
+              <<: *recent_date_filter
+          - unique
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: _INVOCATION_ID
+        description: '{{ doc("_invocation_id") }}' 
+        data_tests: 
+          - not_null:
+              name: test_silver__not_null_pre_token_balances_invocation_id
+              <<: *recent_date_filter

--- a/models/silver/core/silver___pre_token_balances.yml
+++ b/models/silver/core/silver___pre_token_balances.yml
@@ -59,7 +59,7 @@ models:
         description: "{{ doc('_inserted_timestamp') }}"
         data_tests: 
           - not_null: *recent_date_filter
-      - name: _PRE_TOKEN_BALANCE_ID
+      - name: _PRE_TOKEN_BALANCES_ID
         description: '{{ doc("pk") }}'
         data_tests: 
           - not_null:


### PR DESCRIPTION
- Add `silver._pre_token_balances` and `silver._post_token_balances`
- Omitting `_instructions` and `_inner_instructions`
  - `_instructions` only used in `silver.events`, will just include it as a CTE in the model logic
  - `_inner_instructions` will be refactored and surfaced as a regular model `silver.inner_instructions`

Incremental and tests on M
```
15:49:36  Finished running 2 incremental models, 36 data tests, 5 project hooks in 0 hours 0 minutes and 25.43 seconds (25.43s).
15:49:36  
15:49:36  Completed successfully
15:49:36  
15:49:36  Done. PASS=38 WARN=0 ERROR=0 SKIP=0 TOTAL=38
```

Can view on DEV
```
select *
from eclipse_dev.silver._pre_token_balances;

select *
from eclipse_dev.silver._post_token_balances;
```