### PR TITLE
Stats models

### DIFF
--- a/.github/workflows/dbt_run_incremental_core.yml
+++ b/.github/workflows/dbt_run_incremental_core.yml
@@ -1,0 +1,45 @@
+name: dbt_run_incremental_core
+run-name: dbt_run_incremental_core
+
+on:
+  workflow_dispatch:
+    branches:
+      - "main"
+    
+env:
+  DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ vars.PYTHON_VERSION }}"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run -s "eclipse_models,tag:scheduled_core"
+          

--- a/.github/workflows/dbt_run_incremental_non_core.yml
+++ b/.github/workflows/dbt_run_incremental_non_core.yml
@@ -1,0 +1,44 @@
+name: dbt_run_incremental_non_core
+run-name: dbt_run_incremental_non_core
+
+on:
+  workflow_dispatch:
+    branches:
+      - "main" 
+env:
+  DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ vars.PYTHON_VERSION }}"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run -s "eclipse_models,tag:scheduled_core" "eclipse_models,tag:scheduled_non_core" 
+          

--- a/data/github_actions__workflows.csv
+++ b/data/github_actions__workflows.csv
@@ -1,3 +1,5 @@
 workflow_name,workflow_schedule
 dbt_run_streamline_blocks_realtime,"2-59/5 * * * *"
 dbt_run_streamline_block_txs_realtime,"14-59/15 * * * *"
+dbt_run_incremental,"19,49 * * * *"
+dbt_run_incremental_non_core,"4,34 * * * *"

--- a/models/bronze/prices/bronze__complete_native_prices.sql
+++ b/models/bronze/prices/bronze__complete_native_prices.sql
@@ -1,0 +1,29 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+SELECT
+    HOUR,
+    asset_id,
+    symbol,
+    NAME,
+    decimals,
+    price,
+    blockchain,
+    is_imputed,
+    is_deprecated,
+    provider,
+    source,
+    _inserted_timestamp,
+    inserted_timestamp,
+    modified_timestamp,
+    complete_native_prices_id,
+    _invocation_id
+FROM
+    {{ source(
+        'crosschain_silver',
+        'complete_native_prices'
+    ) }}
+WHERE
+    blockchain = 'ethereum'
+    AND symbol = 'ETH' /* just taking eth price for now since this is the native token of Eclipse */

--- a/models/descriptions/gold/stats/ez_core_metrics.md
+++ b/models/descriptions/gold/stats/ez_core_metrics.md
@@ -1,0 +1,65 @@
+{% docs ez_core_metrics_hourly_table_doc %}
+
+A convenience table that aggregates block and transaction related metrics using various aggregate functions such as SUM, COUNT, MIN and MAX from the fact_transactions table, on an hourly basis. Stats for the current hour will be updated as new data arrives.
+
+{% enddocs %}
+
+{% docs block_timestamp_hour %}
+
+The hour of the timestamp of the block.
+
+{% enddocs %}
+
+{% docs block_number_min %}
+
+The minimum block number in the hour.
+
+{% enddocs %}
+
+{% docs block_number_max %}
+
+The maximum block number in the hour.
+
+{% enddocs %}
+
+{% docs block_count %}
+
+The number of blocks in the hour.
+
+{% enddocs %}
+
+{% docs transaction_count %}
+
+The number of transactions in the hour.
+
+{% enddocs %}
+
+{% docs transaction_count_success %}
+
+The number of successful transactions in the hour.
+
+{% enddocs %}
+
+{% docs transaction_count_failed %}
+
+The number of failed transactions in the hour.
+
+{% enddocs %}
+
+{% docs total_fees_native %}
+
+The sum of all fees in the hour, in Lamports.
+
+{% enddocs %}
+
+{% docs total_fees_usd %}
+
+The sum of all fees in the hour, in USD.
+
+{% enddocs %}
+
+{% docs unique_signers_count %}
+
+The count of unique first signers for transactions in the hour.
+
+{% enddocs %}

--- a/models/gold/stats/stats__ez_core_metrics_hourly.sql
+++ b/models/gold/stats/stats__ez_core_metrics_hourly.sql
@@ -1,0 +1,55 @@
+{{ 
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = 'block_timestamp_hour',
+        cluster_by = ['block_timestamp_hour'],
+        meta ={ 
+            'database_tags': { 
+                'table': { 
+                    'PURPOSE': 'STATS, METRICS, CORE, HOURLY',
+                }
+            }
+        },
+        tags = ['scheduled_non_core','exclude_change_tracking']
+    ) 
+}}
+
+SELECT
+    block_timestamp_hour,
+    block_number_min,
+    block_number_max,
+    block_count,
+    transaction_count,
+    transaction_count_success,
+    transaction_count_failed,
+    unique_signers_count,
+    total_fees AS total_fees_native,
+    ROUND(
+        (
+            total_fees / pow(
+                10,
+                9
+            )
+        ) * p.price,
+        2
+    ) AS total_fees_usd,
+    core_metrics_hourly_id AS ez_core_metrics_hourly_id,
+    s.inserted_timestamp AS inserted_timestamp,
+    s.modified_timestamp AS modified_timestamp
+FROM
+    {{ ref('silver__core_metrics_hourly') }} s
+LEFT JOIN 
+    {{ ref('silver__complete_native_prices') }} p
+    ON s.block_timestamp_hour = p.hour
+{% if is_incremental() %}
+WHERE
+    s.modified_timestamp >= (
+        SELECT
+            MAX(
+                modified_timestamp
+            )
+        FROM
+            {{ this }}
+    )
+{% endif %}

--- a/models/gold/stats/stats__ez_core_metrics_hourly.yml
+++ b/models/gold/stats/stats__ez_core_metrics_hourly.yml
@@ -1,0 +1,32 @@
+version: 2
+models:
+  - name: stats__ez_core_metrics_hourly
+    description: '{{ doc("ez_core_metrics_hourly_table_doc") }}'
+
+    columns:
+      - name: BLOCK_TIMESTAMP_HOUR
+        description: '{{ doc("block_timestamp_hour") }}'
+      - name: BLOCK_NUMBER_MIN
+        description: '{{ doc("block_number_min") }}'
+      - name: BLOCK_NUMBER_MAX
+        description: '{{ doc("block_number_max") }}'
+      - name: BLOCK_COUNT
+        description: '{{ doc("block_count") }}'
+      - name: TRANSACTION_COUNT
+        description: '{{ doc("transaction_count") }}'
+      - name: TRANSACTION_COUNT_SUCCESS
+        description: '{{ doc("transaction_count_success") }}'
+      - name: TRANSACTION_COUNT_FAILED
+        description: '{{ doc("transaction_count_failed") }}'
+      - name: UNIQUE_SIGNERS_COUNT
+        description: '{{ doc("unique_signers_count") }}'
+      - name: TOTAL_FEES_NATIVE
+        description: '{{ doc("total_fees_native") }}'
+      - name: TOTAL_FEES_USD
+        description: '{{ doc("total_fees_usd") }}'
+      - name: EZ_CORE_METRICS_HOURLY_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/silver/prices/silver__complete_native_prices.sql
+++ b/models/silver/prices/silver__complete_native_prices.sql
@@ -1,0 +1,38 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'complete_native_prices_id',
+    cluster_by = ['HOUR::DATE'],
+    tags = ['scheduled_non_core']
+) }}
+
+SELECT
+    HOUR,
+    asset_id,
+    symbol,
+    NAME,
+    decimals,
+    price,
+    blockchain,
+    is_imputed,
+    is_deprecated,
+    provider,
+    source,
+    _inserted_timestamp,
+    inserted_timestamp,
+    modified_timestamp,
+    complete_native_prices_id,
+    _invocation_id
+FROM
+    {{ ref('bronze__complete_native_prices') }}
+{% if is_incremental() %}
+WHERE
+    modified_timestamp >= (
+        SELECT
+            MAX(
+                modified_timestamp
+            )
+        FROM
+            {{ this }}
+    )
+{% endif %}

--- a/models/silver/prices/silver__complete_native_prices.yml
+++ b/models/silver/prices/silver__complete_native_prices.yml
@@ -1,0 +1,37 @@
+version: 2
+models:
+  - name: silver__complete_native_prices
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - HOUR
+            - SYMBOL
+
+    columns:
+      - name: HOUR
+        tests:
+          - not_null
+      - name: SYMBOL
+        tests:
+          - not_null
+      - name: BLOCKCHAIN
+        tests:
+          - not_null
+      - name: PROVIDER
+        tests:
+          - not_null
+      - name: PRICE
+        tests: 
+          - not_null
+      - name: IS_IMPUTED
+        tests: 
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - not_null
+      - name: MODIFIED_TIMESTAMP
+        tests:
+          - not_null
+      - name: COMPLETE_NATIVE_PRICES_ID
+        tests:
+          - unique

--- a/models/silver/stats/silver__core_metrics_hourly.sql
+++ b/models/silver/stats/silver__core_metrics_hourly.sql
@@ -1,0 +1,159 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_timestamp_hour",
+    cluster_by = ['block_timestamp_hour::DATE', 'modified_timestamp::DATE'],
+    tags = ['curated','scheduled_non_core']
+) }}
+/* run incremental query to get relevant dates */
+{% if execute %}
+    {% if is_incremental() %}
+        {% set query_its %}
+        SELECT
+            MAX(_inserted_timestamp) _inserted_timestamp
+        FROM
+            {{ this }}
+        {% endset %}
+        {% set max_inserted_timestamp = run_query(query_its).columns[0].values()[0] %}
+        {% set query %}
+        SELECT
+            COALESCE(
+                NULLIF(
+                    LISTAGG(
+                        DISTINCT block_timestamp :: DATE,
+                        ''','''
+                    ),
+                    ''
+                ),
+                SYSDATE() :: DATE :: STRING
+            ) block_dates
+        FROM
+            {{ ref('silver__transactions') }}
+        WHERE
+            _inserted_timestamp >= '{{ max_inserted_timestamp }}'
+        {% endset %}
+        {% set block_dates = run_query(query).columns [0].values() [0] %}
+    {% endif %}
+{% endif %}
+
+WITH block_stats AS (
+    SELECT
+        DATE_TRUNC(
+            'hour',
+            block_timestamp
+        ) AS block_timestamp_hour,
+        MIN(block_id) AS block_number_min,
+        MAX(block_id) AS block_number_max,
+        COUNT(
+            DISTINCT block_id
+        ) AS block_count,
+        MAX(_inserted_timestamp) AS _inserted_timestamp
+    FROM
+        {{ ref('silver__blocks') }}
+    WHERE
+        block_timestamp_hour < DATE_TRUNC(
+            'hour',
+            CURRENT_TIMESTAMP
+        )
+        {% if is_incremental() %}
+        AND block_timestamp :: DATE IN(
+            '{{ block_dates }}'
+        )
+        {% endif %}
+    GROUP BY
+        1
+),
+tx_stats_base AS (
+    SELECT
+        date_trunc('hour', block_timestamp) AS block_timestamp_hour,
+        tx_id,
+        succeeded,
+        signers,
+        fee,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__transactions') }}
+    WHERE
+        block_timestamp_hour < DATE_TRUNC(
+            'hour',
+            CURRENT_TIMESTAMP
+        )
+        {% if is_incremental() %}
+        AND block_timestamp :: DATE IN(
+            '{{ block_dates }}'
+        )
+        {% endif %}
+    UNION
+    SELECT
+        date_trunc('hour', block_timestamp) AS block_timestamp_hour,
+        tx_id,
+        succeeded,
+        signers,
+        fee,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__votes') }}
+    WHERE
+        block_timestamp_hour < DATE_TRUNC(
+            'hour',
+            CURRENT_TIMESTAMP
+        )
+        {% if is_incremental() %}
+        AND block_timestamp :: DATE IN(
+            '{{ block_dates }}'
+        )
+        {% endif %}
+),
+tx_stats AS (
+    SELECT
+        block_timestamp_hour,
+        COUNT(
+            1
+        ) AS transaction_count,
+        SUM(
+            CASE
+                WHEN succeeded THEN 1
+                ELSE 0
+            END
+        ) AS transaction_count_success,
+        SUM(
+            CASE
+                WHEN NOT succeeded THEN 1
+                ELSE 0
+            END
+        ) AS transaction_count_failed,
+        COUNT(
+            DISTINCT signers [0]
+        ) AS unique_signers_count,
+        SUM(fee) AS total_fees,
+        MAX(_inserted_timestamp) AS _inserted_timestamp
+    FROM
+        tx_stats_base
+    GROUP BY
+        1
+)
+SELECT
+    A.block_timestamp_hour,
+    A.block_number_min,
+    A.block_number_max,
+    A.block_count,
+    b.transaction_count,
+    b.transaction_count_success,
+    b.transaction_count_failed,
+    b.unique_signers_count,
+    b.total_fees,
+    greatest(
+        A._inserted_timestamp,
+        b._inserted_timestamp
+    ) AS _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['a.block_timestamp_hour']
+    ) }} AS core_metrics_hourly_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    block_stats A
+LEFT JOIN 
+    tx_stats b
+    ON A.block_timestamp_hour = b.block_timestamp_hour

--- a/models/silver/stats/silver__core_metrics_hourly.yml
+++ b/models/silver/stats/silver__core_metrics_hourly.yml
@@ -1,0 +1,79 @@
+version: 2
+models:
+  - name: silver__core_metrics_hourly
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCK_TIMESTAMP_HOUR
+    columns:
+      - name: BLOCK_TIMESTAMP_HOUR
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: BLOCK_NUMBER_MIN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_NUMBER_MAX
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_COUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TRANSACTION_COUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TRANSACTION_COUNT_SUCCESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TRANSACTION_COUNT_FAILED
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOTAL_FEES
+        tests:
+          - not_null:
+              where:
+                block_timestamp_hour::date > '2020-03-16' /* ignore first set of metrics */
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - DECIMAL
+                - FLOAT
+                - NUMBER
+      - name: UNIQUE_SIGNERS_COUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -19,6 +19,7 @@ sources:
     schema: silver
     tables:
       - name: number_sequence
+      - name: complete_native_prices
   - name: github_actions
     database: ECLIPSE
     schema: github_actions


### PR DESCRIPTION
- Add `stats` models
  - Add native prices using `ethereum` since it is a dependency for `stats__ez_core_metrics_hourly`
  - Includes both vote and non-vote txs in the transction count

Run native prices and tests on M
`dbt build -s models/bronze/prices/bronze__complete_native_prices.sql models/silver/prices/silver__complete_native_prices.sql -t dev`
```
15:15:41  Finished running 1 view model, 1 incremental model, 10 data tests, 5 project hooks in 0 hours 0 minutes and 20.31 seconds (20.31s).
15:15:42  
15:15:42  Completed successfully
15:15:42  
15:15:42  Done. PASS=12 WARN=0 ERROR=0 SKIP=0 TOTAL=12
```

Run silver and gold metrics on M
`dbt run -s models/silver/stats/silver__core_metrics_hourly.sql models/gold/stats/stats__ez_core_metrics_hourly.sql -t dev `
```
15:22:55  Finished running 2 incremental models, 5 project hooks in 0 hours 0 minutes and 22.96 seconds (22.96s).
15:22:55  
15:22:55  Completed successfully
15:22:55  
```

Tests will fail for metrics on DEV because there are more blocks than transactions causing NULLs for tx stat columns
```
15:16:54  Done. PASS=15 WARN=0 ERROR=6 SKIP=1 TOTAL=22
```

Data on DEV
```
select *
from eclipse_dev.silver.core_metrics_hourly
order by 1;

select *
from eclipse_dev.stats.ez_core_metrics_hourly
order by 1;
```