### PR TITLE
add FR views

### DIFF
--- a/models/silver/core/silver__blocks.sql
+++ b/models/silver/core/silver__blocks.sql
@@ -1,3 +1,5 @@
+-- depends_on: {{ ref('bronze__blocks') }}
+
 {{ config(
   materialized = 'incremental',
   unique_key = "block_id",
@@ -33,7 +35,11 @@ WITH pre_final AS (
         data:result:previousBlockhash::string AS previous_block_hash,
         _inserted_timestamp
     FROM
+        {% if is_incremental() %}
         {{ ref('bronze__blocks') }}
+        {% else %}
+        {{ ref('bronze__FR_blocks') }}
+        {% endif %}
     WHERE
         block_id IS NOT NULL
         AND error IS NULL

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -1,3 +1,5 @@
+-- depends_on: {{ ref('bronze__transactions') }}
+
 {{ config(
     materialized = 'incremental',
     unique_key = "tx_id",
@@ -46,10 +48,14 @@ WITH pre_final AS (
         t.partition_key,
         t._inserted_timestamp
     FROM
+        {% if is_incremental() %}
         {{ ref('bronze__transactions') }} t
-        LEFT OUTER JOIN 
-            {{ ref('silver__blocks') }} b
-            ON b.block_id = t.block_id
+        {% else %}
+        {{ ref('bronze__FR_transactions') }} t
+        {% endif %}
+    LEFT OUTER JOIN 
+        {{ ref('silver__blocks') }} b
+        ON b.block_id = t.block_id
     WHERE
         tx_id IS NOT NULL
         AND (


### PR DESCRIPTION
- Add usage of `bronze__FR_*` views when doing full refreshes on `bronze_blocks` and `bronze_transactions`

FRs and Incrementals
```
-- blocks
16:57:16  Finished running 1 incremental model, 5 project hooks in 0 hours 0 minutes and 12.96 seconds (12.96s).
16:57:16  
16:57:16  Completed successfully
16:57:16  
16:57:16  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1

16:57:53  Finished running 1 incremental model, 5 project hooks in 0 hours 0 minutes and 12.27 seconds (12.27s).
16:57:53  
16:57:53  Completed successfully
16:57:53  
16:57:53  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1

-- transactions
16:58:36  Finished running 1 incremental model, 5 project hooks in 0 hours 0 minutes and 26.91 seconds (26.91s).
16:58:36  
16:58:36  Completed successfully
16:58:36  
16:58:36  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1

16:58:56  Finished running 1 incremental model, 5 project hooks in 0 hours 0 minutes and 13.96 seconds (13.96s).
16:58:56  
16:58:56  Completed successfully
16:58:56  
16:58:56  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
