### PR TITLE
Silver observability

### DIFF
--- a/.github/workflows/dbt_run_observability.yml
+++ b/.github/workflows/dbt_run_observability.yml
@@ -1,0 +1,45 @@
+name: dbt_run_observability
+run-name: dbt_run_observability
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs “At minute 45 past every 4th hour.” (see https://crontab.guru)
+    - cron: '45 */4 * * *'
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ vars.PYTHON_VERSION }}"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt build -s "eclipse_models,tag:observability"

--- a/.github/workflows/dbt_run_observability_full.yml
+++ b/.github/workflows/dbt_run_observability_full.yml
@@ -1,0 +1,45 @@
+name: dbt_run_observability_full
+run-name: dbt_run_observability_full
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs “At 06:00 on day-of-month 1.” (see https://crontab.guru)
+    - cron: '0 6 1 * *'
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ vars.PYTHON_VERSION }}"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt build --vars '{"OBSERV_FULL_TEST":True}' -s "eclipse_models,tag:observability"

--- a/models/silver/_observability/silver_observability__blocks_completeness.sql
+++ b/models/silver/_observability/silver_observability__blocks_completeness.sql
@@ -42,7 +42,7 @@ AND (
         )
         OR (
             {% if var('OBSERV_FULL_TEST') %}
-            block_id >= 6572203 --current min block available
+            block_id >= 6572203 --TODO current min block available
             {% else %}
             block_id >= (
                 SELECT

--- a/models/silver/_observability/silver_observability__blocks_completeness.sql
+++ b/models/silver/_observability/silver_observability__blocks_completeness.sql
@@ -1,0 +1,139 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'test_timestamp',
+    full_refresh = false,
+    tags = ['observability']
+) }}
+
+WITH source AS (
+
+    SELECT
+        block_id,
+        block_timestamp,
+        previous_BLOCK_ID AS true_prev_block_id,
+        LAG(
+            block_id,
+            1
+        ) over (
+            ORDER BY
+                block_id ASC
+        ) AS prev_BLOCK_ID
+    FROM
+        {{ ref('silver__blocks') }} A
+    WHERE
+        block_timestamp < DATEADD(
+            HOUR,
+            -24,
+            SYSDATE()
+        )
+
+{% if is_incremental() %}
+AND (
+        block_timestamp >= DATEADD(
+            HOUR,
+            -96,(
+                SELECT
+                    MAX(
+                        max_block_timestamp
+                    )
+                FROM
+                    {{ this }}
+            )
+        )
+        OR (
+            {% if var('OBSERV_FULL_TEST') %}
+            block_id >= 6572203 --current min block available
+            {% else %}
+            block_id >= (
+                SELECT
+                    MIN(VALUE) - 1
+                FROM
+                    (
+                SELECT
+                    blocks_impacted_array
+                FROM
+                    {{ this }}
+                    qualify ROW_NUMBER() over (
+                ORDER BY
+                    test_timestamp DESC) = 1), LATERAL FLATTEN(input => blocks_impacted_array)
+            )
+            {% endif %}
+        )
+    )
+{% endif %}
+),
+block_gen AS (
+    SELECT
+        _id AS block_id
+    FROM
+        {{ source(
+            'crosschain_silver',
+            'number_sequence'
+        ) }}
+    WHERE
+        _id BETWEEN (
+            SELECT
+                MIN(block_id)
+            FROM
+                source
+        )
+        AND (
+            SELECT
+                MAX(block_id)
+            FROM
+                source
+        )
+)
+SELECT
+    'blocks' AS test_name,
+    MIN(
+        b.block_id
+    ) AS min_block,
+    MAX(
+        b.block_id
+    ) AS max_block,
+    MIN(
+        b.block_timestamp
+    ) AS min_block_timestamp,
+    MAX(
+        b.block_timestamp
+    ) AS max_block_timestamp,
+    COUNT(1) AS blocks_tested,
+    COUNT(
+        CASE
+            WHEN C.block_id IS NOT NULL THEN A.block_id
+        END
+    ) AS blocks_impacted_count,
+    ARRAY_AGG(
+        CASE
+            WHEN C.block_id IS NOT NULL THEN A.block_id
+        END
+    ) within GROUP (
+        ORDER BY
+            A.block_id
+    ) AS blocks_impacted_array,
+    ARRAY_AGG(
+        DISTINCT CASE
+            WHEN C.block_id IS NOT NULL THEN OBJECT_CONSTRUCT(
+                'prev_block_id',
+                C.prev_block_id,
+                'block_id',
+                C.block_id
+            )
+        END
+    ) AS test_failure_details,
+    SYSDATE() AS test_timestamp
+FROM
+    block_gen A
+    LEFT JOIN source b
+    ON A.block_id = b.block_id
+    LEFT JOIN source C
+    ON A.block_id > C.prev_BLOCK_ID
+    AND A.block_id < C.block_id
+    AND C.block_id - C.prev_BLOCK_ID <> 1
+    AND A.block_id = C.true_prev_BLOCK_ID
+WHERE
+    COALESCE(
+        b.prev_block_id,
+        C.prev_block_id
+    ) IS NOT NULL

--- a/models/silver/_observability/silver_observability__blocks_completeness.yml
+++ b/models/silver/_observability/silver_observability__blocks_completeness.yml
@@ -1,0 +1,75 @@
+version: 2
+models:
+  - name: silver_observability__blocks_completeness
+    description: Records of all blocks block gaps (missing blocks) with a timestamp the test was run
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TEST_TIMESTAMP
+    columns:
+      - name: MIN_BLOCK
+        description: The lowest block id in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: MAX_BLOCK
+        description: The highest block id in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: MIN_BLOCK_TIMESTAMP
+        description: The lowest block timestamp in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: MAX_BLOCK_TIMESTAMP
+        description: The highest block timestamp in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: BLOCKS_TESTED
+        description: Count of blocks in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: BLOCKS_IMPACTED_COUNT
+        description: Count of block gaps in the test
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: BLOCKS_IMPACTED_ARRAY
+        description: Array of affected blocks
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - ARRAY
+      - name: TEST_FAILURE_DETAILS
+        description: Array of details of the failure
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - ARRAY
+      - name: TEST_TIMESTAMP
+        description: When the test was run
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ

--- a/models/silver/_observability/silver_observability__blocks_tx_count.sql
+++ b/models/silver/_observability/silver_observability__blocks_tx_count.sql
@@ -5,6 +5,7 @@
     tags = ['observability']
 ) }}
 
+/* CURRENTLY UNUSED UNTIL WE HAVE A WAY TO VERIFY TX COUNTS PER BLOCK */
 WITH base as (
     SELECT 
         block_id,

--- a/models/silver/_observability/silver_observability__blocks_tx_count.sql
+++ b/models/silver/_observability/silver_observability__blocks_tx_count.sql
@@ -17,7 +17,7 @@ WITH base as (
         _inserted_timestamp > (SELECT max(_inserted_timestamp) FROM {{ this }})
     {% else %}
     WHERE 
-        block_id >= 6572203
+        block_id >= 6572203 --TODO current min block available
     {% endif %}
     UNION ALL 
     SELECT 
@@ -31,7 +31,7 @@ WITH base as (
         _inserted_timestamp > (SELECT max(_inserted_timestamp) FROM {{ this }})
     {% else %}
     WHERE 
-        block_id >= 6572203
+        block_id >= 6572203 --TODO current min block available
     {% endif %}
 )
 SELECT 

--- a/models/silver/_observability/silver_observability__blocks_tx_count.yml
+++ b/models/silver/_observability/silver_observability__blocks_tx_count.yml
@@ -1,0 +1,27 @@
+version: 2
+models:
+  - name: silver_observability__blocks_tx_count
+    description: Records of all block transaction counts. This is an intermediate table used for transaction completeness testing
+    columns:
+      - name: BLOCK_ID
+        description: The lowest block id in the test
+        tests:
+          - not_null
+          - unique
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: TRANSACTION_COUNT
+        description: The lowest block id in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: _INSERTED_TIMESTAMP
+        description: The lowest block timestamp in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ


### PR DESCRIPTION
- Add `observability` models
  - transaction completeness is omitted at this time because there is no 3rd party source to compare

full observe
`dbt run --vars '{"OBSERV_FULL_TEST":True}' -s "eclipse_models,tag:observability`
```
15:51:46  Finished running 2 incremental models, 5 project hooks in 0 hours 0 minutes and 15.46 seconds (15.46s).
15:51:47  
15:51:47  Completed successfully
15:51:47  
15:51:47  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
```

incremental observe
`dbt build -s "eclipse_models,tag:observability"`
```
15:55:52  Finished running 2 incremental models, 27 data tests, 5 project hooks in 0 hours 0 minutes and 21.31 seconds (21.31s).
15:55:53  
15:55:53  Completed successfully
15:55:53  
15:55:53  Done. PASS=29 WARN=0 ERROR=0 SKIP=0 TOTAL=29
```