### PR TITLE
Fix tx and votes incremental logic

### DIFF
--- a/models/silver/core/silver__transactions.yml
+++ b/models/silver/core/silver__transactions.yml
@@ -8,7 +8,11 @@ models:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
-          - not_null: *recent_date_filter
+          - not_null:
+              config:
+                where: >
+                  _inserted_timestamp >= current_date - 7
+                  AND block_timestamp < current_timestamp - INTERVAL '2 HOUR'
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:

--- a/models/silver/core/silver__votes.sql
+++ b/models/silver/core/silver__votes.sql
@@ -3,7 +3,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = ['tx_id','vote_index'],
-    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    incremental_predicates = ['DBT_INTERNAL_DEST.block_timestamp >= (select min(block_timestamp) from ' ~ generate_tmp_view_name(this) ~ ') OR DBT_INTERNAL_DEST.block_timestamp IS NULL'],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['scheduled_core']
@@ -89,15 +89,54 @@ prev_null_block_timestamp_txs AS (
         ON b.block_id = t.block_id
     WHERE
         t.block_timestamp::DATE IS NULL
-)
+),
 {% endif %}
+combined AS (
+    SELECT
+        block_timestamp,
+        block_id,
+        tx_id,
+        index,
+        recent_block_hash,
+        silver.udf_ordered_signers(account_keys) AS signers,
+        fee,
+        succeeded,
+        account_keys,
+        vote_index,
+        event_type,
+        instruction,
+        version,
+        partition_key,
+        _inserted_timestamp,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_id', 'vote_index']
+        ) }} AS votes_id,
+        sysdate() AS inserted_timestamp,
+        sysdate() AS modified_timestamp,
+        '{{ invocation_id }}' AS _invocation_id
+    FROM
+        pre_final b 
+    {% if is_incremental() %}
+    UNION
+    SELECT
+        *,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_id', 'vote_index']
+        ) }} AS votes_id,
+        sysdate() AS inserted_timestamp,
+        sysdate() AS modified_timestamp,
+        '{{ invocation_id }}' AS _invocation_id
+    FROM
+        prev_null_block_timestamp_txs
+    {% endif %}
+)
 SELECT
     block_timestamp,
     block_id,
     tx_id,
     index,
     recent_block_hash,
-    silver.udf_ordered_signers(account_keys) AS signers,
+    signers,
     fee,
     succeeded,
     account_keys,
@@ -107,26 +146,11 @@ SELECT
     version,
     partition_key,
     _inserted_timestamp,
-    {{ dbt_utils.generate_surrogate_key(
-        ['tx_id', 'vote_index']
-    ) }} AS votes_id,
-    sysdate() AS inserted_timestamp,
-    sysdate() AS modified_timestamp,
-    '{{ invocation_id }}' AS _invocation_id
+    votes_id,
+    inserted_timestamp,
+    modified_timestamp,
+    _invocation_id
 FROM
-    pre_final b 
+    combined
 QUALIFY
     row_number() OVER (PARTITION BY block_id, tx_id ORDER BY _inserted_timestamp DESC) = 1
-{% if is_incremental() %}
-UNION
-SELECT
-    *,
-    {{ dbt_utils.generate_surrogate_key(
-        ['tx_id', 'vote_index']
-    ) }} AS votes_id,
-    sysdate() AS inserted_timestamp,
-    sysdate() AS modified_timestamp,
-    '{{ invocation_id }}' AS _invocation_id
-FROM
-    prev_null_block_timestamp_txs
-{% endif %}

--- a/models/silver/core/silver__votes.yml
+++ b/models/silver/core/silver__votes.yml
@@ -8,7 +8,11 @@ models:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
-          - not_null: *recent_date_filter
+          - not_null:
+              config:
+                where: >
+                  _inserted_timestamp >= current_date - 7
+                  AND block_timestamp < current_timestamp - INTERVAL '2 HOUR'
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
         tests:


### PR DESCRIPTION
- Fix issue with `silver.votes` and `silver.transactions` where duplicates can occur
  - Cannot use dynamic predicate on `block_timestamp` since it can be NULL
  - Deduplicate after the UNION

DEV no longer has duplicates after re-running with the updated logic
```
select tx_id
from eclipse_dev.silver.votes
group by 1
having count(*) > 1;

select tx_id
from eclipse_dev.silver.transactions
group by 1
having count(*) > 1;
```