### PR TITLE
don't include txs that come in ahead of blocks

### DIFF
--- a/models/silver/core/silver___post_token_balances.sql
+++ b/models/silver/core/silver___post_token_balances.sql
@@ -30,15 +30,15 @@ SELECT
 FROM
     {{ ref('silver__transactions') }} t,
     table(flatten(post_token_balances)) b
-{% if is_incremental() %}
 WHERE
-    _inserted_timestamp >= (
+    block_timestamp IS NOT NULL
+{% if is_incremental() %}
+    AND _inserted_timestamp >= (
         SELECT
             MAX(_inserted_timestamp)
         FROM
             {{ this }}
     )
 {% else %}
-WHERE
-    _inserted_timestamp::date = '2024-09-12'
+    AND _inserted_timestamp::date = '2024-09-12'
 {% endif %}

--- a/models/silver/core/silver___pre_token_balances.sql
+++ b/models/silver/core/silver___pre_token_balances.sql
@@ -30,15 +30,15 @@ SELECT
 FROM
     {{ ref('silver__transactions') }} t,
     table(flatten(pre_token_balances)) b
-{% if is_incremental() %}
 WHERE
-    _inserted_timestamp >= (
+    block_timestamp IS NOT NULL
+{% if is_incremental() %}
+    AND _inserted_timestamp >= (
         SELECT
             MAX(_inserted_timestamp)
         FROM
             {{ this }}
     )
 {% else %}
-WHERE
-    _inserted_timestamp::date = '2024-09-12'
+    AND _inserted_timestamp::date = '2024-09-12'
 {% endif %}

--- a/models/silver/core/silver__events.sql
+++ b/models/silver/core/silver__events.sql
@@ -31,12 +31,12 @@ WITH base_transactions AS (
         _inserted_timestamp
     FROM
         {{ ref('silver__transactions') }} 
+    WHERE
+        block_timestamp IS NOT NULL
     {% if is_incremental() %}
-    WHERE
-        _inserted_timestamp >= '{{ max_inserted_timestamp }}'
+        AND _inserted_timestamp >= '{{ max_inserted_timestamp }}'
     {% else %}
-    WHERE
-        _inserted_timestamp::date = '2024-09-12'
+        AND _inserted_timestamp::date = '2024-09-12'
     {% endif %}
 ),
 base_instructions AS (

--- a/models/silver/stats/silver__core_metrics_hourly.sql
+++ b/models/silver/stats/silver__core_metrics_hourly.sql
@@ -30,7 +30,8 @@
         FROM
             {{ ref('silver__transactions') }}
         WHERE
-            _inserted_timestamp >= '{{ max_inserted_timestamp }}'
+            block_timestamp IS NOT NULL
+            AND _inserted_timestamp >= '{{ max_inserted_timestamp }}'
         {% endset %}
         {% set block_dates = run_query(query).columns [0].values() [0] %}
     {% endif %}
@@ -74,7 +75,8 @@ tx_stats_base AS (
     FROM
         {{ ref('silver__transactions') }}
     WHERE
-        block_timestamp_hour < DATE_TRUNC(
+        block_timestamp IS NOT NULL
+        AND block_timestamp_hour < DATE_TRUNC(
             'hour',
             CURRENT_TIMESTAMP
         )
@@ -94,7 +96,8 @@ tx_stats_base AS (
     FROM
         {{ ref('silver__votes') }}
     WHERE
-        block_timestamp_hour < DATE_TRUNC(
+        block_timestamp IS NOT NULL
+        AND block_timestamp_hour < DATE_TRUNC(
             'hour',
             CURRENT_TIMESTAMP
         )


### PR DESCRIPTION
- Add `block_timestamp IS NOT NULL` predicate to models that are direct downstreams of `silver.votes` and `silver.transactions`

DEV events no longer has bad records
```
select tx_id, index
from eclipse_dev.silver.events
group by 1,2
having count(*) > 1;

select min(inserted_timestamp)
from eclipse_dev.silver.events
where block_timestamp is null;
```