### PR TITLE
sparse data causing dupes when only 1 record and null tiemstamp

### DIFF
--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -3,7 +3,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = "tx_id",
-    incremental_predicates = ["coalesce(DBT_INTERNAL_DEST.block_timestamp,'2999-12-31') >= (select min(block_timestamp) from " ~ generate_tmp_view_name(this) ~ ")"],
+    incremental_predicates = ["coalesce(DBT_INTERNAL_DEST.block_timestamp,'2999-12-31') >= (select coalesce(min(block_timestamp),'2000-01-01') from " ~ generate_tmp_view_name(this) ~ ")"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['scheduled_core']

--- a/models/silver/core/silver__votes.sql
+++ b/models/silver/core/silver__votes.sql
@@ -3,7 +3,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = ['tx_id','vote_index'],
-    incremental_predicates = ["coalesce(DBT_INTERNAL_DEST.block_timestamp,'2999-12-31') >= (select min(block_timestamp) from " ~ generate_tmp_view_name(this) ~ ")"],
+    incremental_predicates = ["coalesce(DBT_INTERNAL_DEST.block_timestamp,'2999-12-31') >= (select coalesce(min(block_timestamp),'2000-01-01') from " ~ generate_tmp_view_name(this) ~ ")"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['scheduled_core']


### PR DESCRIPTION
- Fix issue with sparse data causing dupes when only 1 record in incremental and we have not yet received the block record causing the `min(block_timestamp)` predicate to return `NULL`