### PR TITLE
Enable block backfill

### DIFF
--- a/models/streamline/core/realtime/streamline__block_txs_realtime.sql
+++ b/models/streamline/core/realtime/streamline__block_txs_realtime.sql
@@ -29,7 +29,7 @@ WITH blocks AS (
         {{ ref("streamline__blocks") }}
     WHERE
         /* Find the earliest block available from the node provider */
-        block_id >= {{ min_block_id }}
+        block_id >= 6572203
     EXCEPT
     SELECT
         block_id

--- a/models/streamline/core/streamline__node_min_block_available.sql
+++ b/models/streamline/core/streamline__node_min_block_available.sql
@@ -9,7 +9,7 @@ WITH node_response AS (
     SELECT
         {{ target.database }}.live.udf_api(
             'POST',
-            'https://mainnetbeta-rpc.eclipse.xyz',
+            'https://eclipse.lgns.net:443',
             OBJECT_CONSTRUCT(
                 'Content-Type',
                 'application/json'


### PR DESCRIPTION
- Change service node in min block available view so we can start backfilling data from before block `6572203`
  - Start with blocks backfill, keep transactions at block `>= 6572203` 