### PR TITLE
filter out null responses; add buffer to realtime

### DIFF
--- a/models/silver/core/silver__blocks.sql
+++ b/models/silver/core/silver__blocks.sql
@@ -43,6 +43,7 @@ WITH pre_final AS (
     WHERE
         block_id IS NOT NULL
         AND error IS NULL
+        AND data IS NOT NULL
         {% if is_incremental() %}
         AND _inserted_timestamp >= '{{ max_inserted_timestamp }}'
         {% endif %}

--- a/models/streamline/core/complete/streamline__blocks_complete.sql
+++ b/models/streamline/core/complete/streamline__blocks_complete.sql
@@ -26,6 +26,7 @@ WHERE
         FROM
             {{ this }}
     )
+    AND data IS NOT NULL
 {% else %}
     {{ ref('bronze__FR_blocks') }}
 {% endif %}

--- a/models/streamline/core/streamline__chainhead.sql
+++ b/models/streamline/core/streamline__chainhead.sql
@@ -24,4 +24,4 @@ SELECT
             []
         ),
         'Vault/prod/eclipse/mainnet'
-    ) :data :result :: INT AS block_id
+    ) :data :result :: INT - 50 AS block_id


### PR DESCRIPTION
- exclude block responses with `NULL` data from landing in `complete` and `silver` models
- add 50 blocks buffer to `chainhead` call for situations where the most current block doesn't return data


Test succeeded on `silver.blocks` and `core.fact_blocks` after rerunning with new logic:
```
19:29:58  Finished running 39 data tests, 5 project hooks in 0 hours 0 minutes and 47.17 seconds (47.17s).
19:29:58  
19:29:58  Completed successfully
19:29:58  
19:29:58  Done. PASS=39 WARN=0 ERROR=0 SKIP=0 TOTAL=39
```