### PR TITLE
filter out null response in solar_dex LQ

### DIFF
--- a/models/gold/defi/defi__fact_solar_dex_tvl.sql
+++ b/models/gold/defi/defi__fact_solar_dex_tvl.sql
@@ -25,3 +25,5 @@ SELECT
     SYSDATE() AS modified_timestamp
 FROM
     lq
+WHERE
+    response IS NOT NULL

--- a/models/gold/defi/defi__fact_solar_dex_tvl.yml
+++ b/models/gold/defi/defi__fact_solar_dex_tvl.yml
@@ -11,7 +11,7 @@ models:
         data_tests:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 2
+              interval: 1
       - name: tvl
         data_tests:
          - not_null: *recent_date_filter


### PR DESCRIPTION
- exclude NULL responses from LQ call
- lower recency test to sooner catch issues with the call failing

Results from run in dev:
<img width="994" alt="image" src="https://github.com/user-attachments/assets/b2f0e098-d6b1-4923-a6f9-5f778598c90b" />
