### PR TITLE
add partition_key filter

### DIFF
--- a/models/streamline/core/complete/streamline__block_txs_complete.sql
+++ b/models/streamline/core/complete/streamline__block_txs_complete.sql
@@ -26,6 +26,15 @@ WHERE
         FROM
             {{ this }}
     )
+    AND partition_key > (
+        SELECT
+            COALESCE(
+                MAX(partition_key),
+                0
+            )
+        FROM
+            {{ this }}
+    )
 {% else %}
     {{ ref('bronze__FR_transactions') }}
 {% endif %}


### PR DESCRIPTION
Model runs 4x faster with partition_key filter

```
17:29:00  Finished running 1 incremental model, 5 project hooks in 0 hours 3 minutes and 38.25 seconds (218.25s).
17:29:00  
17:29:00  Completed successfully
17:29:00  
17:29:00  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```