### PR TITLE
add 1 hour buffer

### DIFF
--- a/models/silver/stats/silver__core_metrics_hourly.sql
+++ b/models/silver/stats/silver__core_metrics_hourly.sql
@@ -54,7 +54,7 @@ WITH block_stats AS (
     WHERE
         block_timestamp_hour < DATE_TRUNC(
             'hour',
-            CURRENT_TIMESTAMP
+            DATEADD('hour', -1, CURRENT_TIMESTAMP)
         )
         {% if is_incremental() %}
         AND block_timestamp :: DATE IN(
@@ -78,7 +78,7 @@ tx_stats_base AS (
         block_timestamp IS NOT NULL
         AND block_timestamp_hour < DATE_TRUNC(
             'hour',
-            CURRENT_TIMESTAMP
+            DATEADD('hour', -1, CURRENT_TIMESTAMP)
         )
         {% if is_incremental() %}
         AND block_timestamp :: DATE IN(
@@ -99,7 +99,7 @@ tx_stats_base AS (
         block_timestamp IS NOT NULL
         AND block_timestamp_hour < DATE_TRUNC(
             'hour',
-            CURRENT_TIMESTAMP
+            DATEADD('hour', -1, CURRENT_TIMESTAMP)
         )
         {% if is_incremental() %}
         AND block_timestamp :: DATE IN(


### PR DESCRIPTION
Add 1 hour buffer to blocks/tx/votes selected
- The most recent hour record consistently returns `null` col values for the tx/vote metrics. This is because txs/votes land in our tables up to an hour later then blocks, so no tx/vote specific data exists and results in `null` values 