### PR TITLE
exclude null block timestamp txs

### DIFF
--- a/models/silver/program_logs/silver__transaction_logs_program_data.sql
+++ b/models/silver/program_logs/silver__transaction_logs_program_data.sql
@@ -22,6 +22,7 @@ WITH base AS (
     WHERE 
         succeeded
         AND log_messages IS NOT NULL
+        AND block_timestamp IS NOT NULL
         {% if is_incremental() %}
         AND _inserted_timestamp >= (SELECT max(_inserted_timestamp) FROM {{ this }}) 
         {% endif %}


### PR DESCRIPTION
Exclude transactions with NULL `block_timestamps`
- These are eventually handled in `silver.transactions`, so exclude the initial ones. Same logic exists in other models downstream from transactions