### PR TITLE
make partitions smaller for streamline block txs requests

### DIFF
--- a/models/streamline/core/complete/streamline__block_txs_complete.sql
+++ b/models/streamline/core/complete/streamline__block_txs_complete.sql
@@ -5,7 +5,7 @@
     materialized = "incremental",
     unique_key = 'block_id',
     merge_exclude_columns = ["inserted_timestamp"],
-    cluster_by = "ROUND(block_id, -5)",
+    cluster_by = "ROUND(block_id, -4)",
 ) }}
 
 SELECT

--- a/models/streamline/core/realtime/streamline__block_txs_realtime.sql
+++ b/models/streamline/core/realtime/streamline__block_txs_realtime.sql
@@ -44,7 +44,7 @@ SELECT
     block_id,
     ROUND(
         block_id,
-        -5
+        -4
     ) :: INT AS partition_key,
     {{ target.database }}.live.udf_api(
         'POST',


### PR DESCRIPTION
Make partition key smaller so that we scan less files in silver ingestion