### PR TITLE
add additional cols for SO

### DIFF
--- a/models/gold/core/core__fact_events.sql
+++ b/models/gold/core/core__fact_events.sql
@@ -4,7 +4,7 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','program_id'],
-    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, event_type, inner_instruction_program_ids)'),
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, event_type, inner_instruction_program_ids, signers[0], index)'),
     tags = ['scheduled_core']
 ) }}
 

--- a/models/gold/core/core__fact_events.sql
+++ b/models/gold/core/core__fact_events.sql
@@ -4,7 +4,7 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','program_id'],
-    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, event_type, inner_instruction_program_ids, signers[0], index)'),
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, event_type, inner_instruction_program_ids, signers[0])'),
     tags = ['scheduled_core']
 ) }}
 

--- a/models/gold/core/core__fact_events_inner.sql
+++ b/models/gold/core/core__fact_events_inner.sql
@@ -4,7 +4,7 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','program_id'],
-    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, event_type, instruction_program_id)'),
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, event_type, instruction_program_id, signers[0], instruction_index, inner_index)'),
     tags = ['scheduled_core']
 ) }}
 

--- a/models/gold/core/core__fact_events_inner.sql
+++ b/models/gold/core/core__fact_events_inner.sql
@@ -4,7 +4,7 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','program_id'],
-    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, event_type, instruction_program_id, signers[0], instruction_index, inner_index)'),
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, event_type, instruction_program_id, signers[0])'),
     tags = ['scheduled_core']
 ) }}
 

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -4,7 +4,10 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, signers[0], log_messages)'),
+    post_hook = [
+        enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, signers[0], log_messages)'),
+        enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON SUBSTRING(log_messages)')
+    ],
     tags = ['scheduled_core']
 ) }}
 

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -4,7 +4,7 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id)'),
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, signers[0], log_messages)'),
     tags = ['scheduled_core']
 ) }}
 

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -4,7 +4,7 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, tx_from, tx_to, mint, index, inner_index, fact_transfers_id)'),
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, tx_from, tx_to, mint, fact_transfers_id)'),
     tags = ['scheduled_core']
 ) }}
 

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -4,7 +4,7 @@
     incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, tx_from, tx_to, mint, fact_transfers_id)'),
+    post_hook = enable_search_optimization('{{this.schema}}','{{this.identifier}}','ON EQUALITY(tx_id, program_id, tx_from, tx_to, mint, index, inner_index, fact_transfers_id)'),
     tags = ['scheduled_core']
 ) }}
 


### PR DESCRIPTION
Add SO on commonly used columns, as well as columns in long-running queries used in the State of Eclipse dashboard.
- For fact_transactions, I tried out both `EQUALITY(log_messages)` (for exact searches, like ARRAY_CONTAINS)  and `SUBSTRING(log_messages)` (for text searches using LIKE '%some_text%'). They have different use cases but the speed increase seemed to be the same, so I decided to only add Equality for now.

example queries used for `log_messages` testing:

`alter table eclipse_dev.core.fact_transactions add SEARCH OPTIMIZATION ON EQUALITY(log_messages);`
`alter table eclipse_dev.core.fact_transactions add SEARCH OPTIMIZATION ON SUBSTRING(log_messages);`
```
with a as (select tx_id as logs_tx_id, replace(logs.value, 'Program log: Instruction: ', '') as instructions
  from eclipse_dev.core.fact_transactions, lateral flatten (input => log_messages) logs
  where replace(logs.value, 'Program log: Instruction: ', '') in 
    ('TwoHopSwap', 'TwoHopSwapV2', 'Swap', 'SwapV2')
and block_timestamp::date >= '2025-01-01')
select count(*) from a;
```