### PR TITLE
add dynamic range predicate

### DIFF
--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -3,7 +3,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = "tx_id",
-    incremental_predicates = ["coalesce(DBT_INTERNAL_DEST.block_timestamp,'2999-12-31') >= (select coalesce(min(block_timestamp),'2000-01-01') from " ~ generate_tmp_view_name(this) ~ ")"],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['scheduled_core']

--- a/models/silver/core/silver__votes.sql
+++ b/models/silver/core/silver__votes.sql
@@ -3,7 +3,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = ['tx_id','vote_index'],
-    incremental_predicates = ["coalesce(DBT_INTERNAL_DEST.block_timestamp,'2999-12-31') >= (select coalesce(min(block_timestamp),'2000-01-01') from " ~ generate_tmp_view_name(this) ~ ")"],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['scheduled_core']


### PR DESCRIPTION
Use dynamic predicates from fsc-utils in silver transactions and votes

- run times on medium warehouse
```
18:48:45  2 of 2 OK created sql incremental model silver.votes ........................... [SUCCESS 20966 in 196.12s]
18:57:06  1 of 2 OK created sql incremental model silver.transactions .................... [SUCCESS 6249308 in 697.36s]
```

Seem to have improved performance compared to previous prod incremental runs on medium with relatively similar number of records:
```
10:46:05  3 of 15 OK created sql incremental model silver.transactions ................... [SUCCESS 7997198 in 3357.77s]
```