### PR TITLE
update units_consumed

### DIFF
--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -44,6 +44,7 @@ WITH pre_final AS (
         t.data:meta:innerInstructions::array AS inner_instructions,
         t.data:meta:logMessages::array AS log_messages,
         t.data:transaction:message:addressTableLookups::array as address_table_lookups,
+        t.data :meta :computeUnitsConsumed :: NUMBER as units_consumed,
         t.data:version::string as version,
         t.partition_key,
         t._inserted_timestamp
@@ -151,7 +152,7 @@ combined AS (
         inner_instructions,
         log_messages,
         address_table_lookups,
-        silver.udf_get_compute_units_consumed(log_messages, instructions) as units_consumed,
+        units_consumed,
         silver.udf_get_compute_units_total(log_messages, instructions) as units_limit,
         silver.udf_get_tx_size(account_keys,instructions,version,address_table_lookups,signers) as tx_size,
         version,


### PR DESCRIPTION
Get `units_consumed` value from raw transaction data, replacing the relatively complex macro
- This value is available from the earliest partition we ingested `6600000` so no need to include cutoff if we need to backfill at some point

- run on 2xl
`9:43:48  1 of 1 OK created sql incremental model silver.transactions .................... [SUCCESS 3711786 in 202.19s]
`
