### PR TITLE
Have each block txs worker make parallel requests

### DIFF
--- a/models/streamline/core/realtime/streamline__block_txs_realtime.sql
+++ b/models/streamline/core/realtime/streamline__block_txs_realtime.sql
@@ -7,10 +7,11 @@
         params ={ "external_table" :"block_txs",
         "sql_limit" :"20000",
         "producer_batch_size" :"20000",
-        "worker_batch_size" :"250",
+        "worker_batch_size" :"500",
         "sql_source" :"{{this.identifier}}",
         "order_by_column": "block_id",
-        "exploded_key": tojson(["result.transactions"]) }
+        "exploded_key": tojson(["result.transactions"]),
+        "async_concurrent_requests" :"10" }
     )
 ) }}
 
@@ -79,5 +80,3 @@ SELECT
     ) AS request
 FROM
     blocks
-ORDER BY
-    block_id


### PR DESCRIPTION
Make each worker use `async_concurrent_requests` for getting block transactions to reduce worker run times which will allow us to process more blocks per worker

Process 500 blocks in ~200s vs. 500 blocks in ~500s in production
![Screenshot 2025-02-03 at 7 03 49 AM](https://github.com/user-attachments/assets/8eb0ce2d-dc26-4623-88cc-347148c43ee4)
