### PR TITLE
update incremental due to null timestamps

### DIFF
--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -3,7 +3,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = "tx_id",
-    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
+    incremental_predicates = ["COALESCE(DBT_INTERNAL_DEST.block_timestamp::DATE,'2099-01-01') >= (select min(block_timestamp::DATE) from " ~ generate_tmp_view_name(this) ~ ")"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['scheduled_core']

--- a/models/silver/core/silver__transactions.yml
+++ b/models/silver/core/silver__transactions.yml
@@ -28,7 +28,7 @@ models:
           - unique:
               config:
                 where: >
-                  block_timestamp::date > current_date - 30
+                  _inserted_timestamp::date >= current_date - 7
       - name: INDEX
         description: "{{ doc('tx_index') }}"
         tests:


### PR DESCRIPTION
Update incremental predicate to update tx's with null block_timestamps as existing logic would never update them. This results in duplicate tx_ids with and without a block_timestamp
- add test for unique tx_id that is based on _inserted_timestamp

incremental run:
`1 of 1 OK created sql incremental model silver.transactions .................... [SUCCESS 176849242 in 592.06s]`

test now correctly catches duplicate ids
```
22:44:16  Completed with 1 error and 0 warnings:
22:44:16  Failure in test unique_silver__transactions_TX_ID (models/silver/core/silver__transactions.yml)
22:44:16    Got 8003775 results, configured to fail if != 0
```

All tx_ids with null block_timestamps have a duplicate with correct block_timestamp, so I will manually delete the former ones. query that confirms:

```
WITH null_tx_ids AS (
    SELECT DISTINCT tx_id
    FROM eclipse.silver.transactions
    WHERE block_timestamp IS NULL
    and _inserted_timestamp >= '2025-02-01'
),
non_null_tx_ids AS (
    SELECT DISTINCT tx_id
    FROM eclipse.silver.transactions
    WHERE block_timestamp IS NOT NULL
    and _inserted_timestamp >= '2025-02-01'
)

SELECT n.tx_id, nn.tx_id as match
FROM null_tx_ids n
inner join non_null_tx_ids nn 
    ON n.tx_id = nn.tx_id
where match is null;
```