### PR TITLE
update node

### DIFF
--- a/models/streamline/core/realtime/streamline__block_txs_realtime.sql
+++ b/models/streamline/core/realtime/streamline__block_txs_realtime.sql
@@ -76,7 +76,7 @@ SELECT
                 )
             )
         ),
-        'Vault/prod/eclipse/mainnet'
+        'Vault/prod/eclipse/private/mainnet'
     ) AS request
 FROM
     blocks

--- a/models/streamline/core/realtime/streamline__block_txs_realtime_2.sql
+++ b/models/streamline/core/realtime/streamline__block_txs_realtime_2.sql
@@ -83,7 +83,7 @@ SELECT
                 )
             )
         ),
-        'Vault/prod/eclipse/mainnet'
+        'Vault/prod/eclipse/private/mainnet'
     ) AS request
 FROM
     blocks

--- a/models/streamline/core/realtime/streamline__blocks_realtime.sql
+++ b/models/streamline/core/realtime/streamline__blocks_realtime.sql
@@ -74,7 +74,7 @@ SELECT
                 )
             )
         ),
-        'Vault/prod/eclipse/mainnet'
+        'Vault/prod/eclipse/private/mainnet'
     ) AS request
 FROM
     blocks

--- a/models/streamline/core/streamline__chainhead.sql
+++ b/models/streamline/core/streamline__chainhead.sql
@@ -23,5 +23,5 @@ SELECT
             'params',
             []
         ),
-        'Vault/prod/eclipse/mainnet'
+        'Vault/prod/eclipse/private/mainnet'
     ) :data :result :: INT - 50 AS block_id

--- a/models/streamline/core/streamline__node_min_block_available.sql
+++ b/models/streamline/core/streamline__node_min_block_available.sql
@@ -36,7 +36,7 @@ WITH node_response AS (
                     )
                 )
             ),
-            'Vault/prod/eclipse/mainnet'
+            'Vault/prod/eclipse/private/mainnet'
         ) AS DATA
 )
 SELECT


### PR DESCRIPTION
Switch node location as Eclipse is shutting down luganodes

- LQ runs as expected in SF
![image](https://github.com/user-attachments/assets/0d507220-98ec-4732-8255-c5fef58c5cf6)

Model Run:
-  `dbt run -s streamline__block_txs_complete streamline__block_txs_realtime --vars '{STREAMLINE_INVOKE_STREAMS: True}' -t dev`

```
20:31:50  1 of 2 OK created sql incremental model streamline.block_txs_complete .......... [SUCCESS 619 in 60.34s]
20:31:50  Running macro `if_data_call_function`: Calling udf streamline.udf_bulk_rest_api_v2 with params: 
{
  "async_concurrent_requests": "10",
  "exploded_key": "[\"result.transactions\"]",
  "external_table": "block_txs",
  "order_by_column": "block_id",
  "producer_batch_size": "20000",
  "sql_limit": "2",
  "sql_source": "{{this.identifier}}",
  "worker_batch_size": "500"
}
 on {{this.schema}}.{{this.identifier}}
20:32:11  2 of 2 OK created sql view model streamline.block_txs_realtime ................. [SUCCESS 1 in 21.74s]
```