### PR TITLE
get min partition same as what the request view would do

### DIFF
--- a/models/streamline/core/complete/streamline__block_txs_complete.sql
+++ b/models/streamline/core/complete/streamline__block_txs_complete.sql
@@ -1,5 +1,6 @@
 -- depends_on: {{ ref('bronze__transactions') }}
 -- depends_on: {{ ref('bronze__FR_transactions') }}
+-- depends_on: {{ ref('streamline__blocks') }}
 
 {{ config (
     materialized = "incremental",
@@ -7,6 +8,27 @@
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = "ROUND(block_id, -4)",
 ) }}
+
+{% if execute %}
+    {% set min_partition_key_query %}
+        SELECT round(min(block_id),-4)::int AS min_partition_key
+        FROM (
+            SELECT
+                block_id
+            FROM
+                {{ ref("streamline__blocks") }}
+            WHERE
+                /* Find the earliest block available from the node provider */
+                block_id >= 6572203
+            EXCEPT
+            SELECT
+                block_id
+            FROM
+                {{ this }}
+        )
+    {% endset %}
+    {% set min_partition_key = run_query(min_partition_key_query)[0][0] %}
+{% endif %}
 
 SELECT
     block_id,
@@ -20,18 +42,10 @@ FROM
 {% if is_incremental() %}
     {{ ref('bronze__transactions') }}
 WHERE
-    _inserted_timestamp >= (
+    partition_key >= {{ min_partition_key }}
+    AND _inserted_timestamp >= (
         SELECT
-            COALESCE(MAX(_INSERTED_TIMESTAMP), '1970-01-01' :: DATE) max_INSERTED_TIMESTAMP
-        FROM
-            {{ this }}
-    )
-    AND partition_key >= (
-        SELECT
-            COALESCE(
-                MAX(partition_key),
-                0
-            )
+            coalesce(max(_inserted_timestamp), '1970-01-01' :: DATE) AS max_inserted_timestamp
         FROM
             {{ this }}
     )


### PR DESCRIPTION
Fix issue when there are gaps before the current `max()` in the completed table which then causes the window of requests to become static and request the same blocks over and over

`dbt run -s streamline__block_txs_complete -t prod`
```
16:26:00  1 of 1 OK created sql incremental model streamline.block_txs_complete .......... [SUCCESS 20500 in 104.69s]
```