### PR TITLE
update txs/votes to use new block txs pipeline

### DIFF
--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('bronze__transactions') }}
+-- depends_on: {{ ref('bronze__transactions_2') }}
 
 {{ config(
     materialized = 'incremental',
@@ -20,6 +21,9 @@
     {% set max_inserted_timestamp = run_query(max_inserted_query)[0][0] %}
     {% endif %}
 {% endif %}
+
+{% set cutover_block_id = 54084999 %}
+{% set cutover_partition_key = 54080000 %}
 
 WITH pre_final AS (
     SELECT
@@ -58,7 +62,8 @@ WITH pre_final AS (
         {{ ref('silver__blocks') }} b
         ON b.block_id = t.block_id
     WHERE
-        tx_id IS NOT NULL
+        t.block_id < {{cutover_block_id}}
+        AND tx_id IS NOT NULL
         AND (
             coalesce(t.data:transaction:message:instructions[0]:programId::STRING,'') <> 'Vote111111111111111111111111111111111111111'
             OR array_size(t.data:transaction:message:instructions) > 1
@@ -68,6 +73,53 @@ WITH pre_final AS (
         {% else %}
         AND t._inserted_timestamp::date = '2024-09-12'
         {% endif %}
+        AND t.partition_key < {{ cutover_partition_key }}
+    UNION ALL
+    SELECT
+        to_timestamp_ntz(t.value:"result.blockTime"::int) AS block_timestamp,
+        t.block_id,
+        t.data:transaction:signatures[0]::string AS tx_id,
+        t.value:array_index as index,
+        t.data:transaction:message:recentBlockhash::string AS recent_block_hash,
+        t.data:meta:fee::number AS fee,
+        CASE
+            WHEN is_null_value(t.data:meta:err) THEN 
+                TRUE
+            ELSE 
+                FALSE
+        END AS succeeded,
+        t.data:transaction:message:accountKeys::array AS account_keys,
+        t.data:meta:preBalances::array AS pre_balances,
+        t.data:meta:postBalances::array AS post_balances,
+        t.data:meta:preTokenBalances::array AS pre_token_balances,
+        t.data:meta:postTokenBalances::array AS post_token_balances,
+        t.data:transaction:message:instructions::array AS instructions,
+        t.data:meta:innerInstructions::array AS inner_instructions,
+        t.data:meta:logMessages::array AS log_messages,
+        t.data:transaction:message:addressTableLookups::array as address_table_lookups,
+        t.data :meta :computeUnitsConsumed :: NUMBER as units_consumed,
+        t.data:version::string as version,
+        t.partition_key,
+        t._inserted_timestamp
+    FROM
+        {% if is_incremental() %}
+        {{ ref('bronze__transactions_2') }} t
+        {% else %}
+        {{ ref('bronze__FR_transactions_2') }} t
+        {% endif %}
+    WHERE
+        t.block_id >= {{ cutover_block_id }}
+        AND tx_id IS NOT NULL
+        AND (
+            coalesce(t.data:transaction:message:instructions[0]:programId::STRING,'') <> 'Vote111111111111111111111111111111111111111'
+            OR array_size(t.data:transaction:message:instructions) > 1
+        )
+        {% if is_incremental() %}
+        AND t._inserted_timestamp >= '{{ max_inserted_timestamp }}'
+        {% else %}
+        AND t.partition_key < 0 /* keep this here, if we ever do a full refresh this should select no data from _2  */
+        {% endif %}
+        AND t.partition_key >= {{ cutover_partition_key}}
 ),
 {% if is_incremental() %}
 prev_null_block_timestamp_txs AS (


### PR DESCRIPTION
- Update silver.transactions to use v2 block txs data after cutoffs
- Update silver.votes to use v2 block txs data after cutoffs

inc runs:
```
20:29:47  1 of 1 OK created sql incremental model silver.transactions .................... [SUCCESS 5543033 in 174.67s]
20:32:46  1 of 1 OK created sql incremental model silver.votes ........................... [SUCCESS 618288 in 103.02s]
```

test run:
```
23:03:00  Finished running 33 data tests, 5 project hooks in 0 hours 5 minutes and 22.25 seconds (322.25s).
23:03:01  Completed successfully
23:03:01  Done. PASS=33 WARN=0 ERROR=0 SKIP=0 TOTAL=33
```

Counts match up with prod:
![image](https://github.com/user-attachments/assets/03154d54-0877-48be-bf4b-2d58bfdf608b)
