### PR TITLE
Update/tx complete incremental and merge pred

### DIFF
--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -4,7 +4,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = "tx_id",
-    incremental_predicates = ["COALESCE(DBT_INTERNAL_DEST.block_timestamp::DATE,'2099-01-01') >= (select min(block_timestamp::DATE) from " ~ generate_tmp_view_name(this) ~ ")"],
+    incremental_predicates = ["dynamic_range_predicate", "block_timestamp::date"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['scheduled_core']


### PR DESCRIPTION
1. Revert `silver.transactions` to use dynamic predicate. With the new pipeline, there shouldn't be `null` `block_timestamp`'s anymore which initially led us to change the predicate logic.
2. Update complete_2 table to address issue where gaps can cause the same blocks to be continuously requested -- [reference pr for v1 complete table](https://github.com/FlipsideCrypto/eclipse-models/pull/55)


- dbt run -s streamline__block_txs_complete_2 -t prod
`19:17:24  1 of 1 OK created sql incremental model streamline.block_txs_complete_2 ........ [SUCCESS 3134 in 72.25s]
`
