### PR TITLE
update unique test, removed col from events_inner

### DIFF
--- a/models/gold/core/core__fact_blocks.yml
+++ b/models/gold/core/core__fact_blocks.yml
@@ -13,7 +13,7 @@ models:
         data_tests:
           - dbt_expectations.expect_column_to_exist
           - not_null: *recent_date_filter
-          - unique
+          - unique: *recent_date_filter
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         data_tests:

--- a/models/gold/core/core__fact_events.yml
+++ b/models/gold/core/core__fact_events.yml
@@ -10,7 +10,7 @@ models:
           combination_of_columns:
             - TX_ID
             - INDEX
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"

--- a/models/gold/core/core__fact_events_inner.sql
+++ b/models/gold/core/core__fact_events_inner.sql
@@ -32,7 +32,6 @@ SELECT
     program_id,
     event_type,
     instruction,
-    _inserted_timestamp,
     events_inner_id AS fact_events_inner_id,
     sysdate() AS inserted_timestamp,
     sysdate() AS modified_timestamp

--- a/models/gold/core/core__fact_events_inner.yml
+++ b/models/gold/core/core__fact_events_inner.yml
@@ -11,7 +11,7 @@ models:
             - TX_ID
             - INSTRUCTION_INDEX
             - INNER_INDEX
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
@@ -67,11 +67,6 @@ models:
         data_tests:
           - dbt_expectations.expect_column_to_exist 
           - not_null: *recent_date_filter
-      - name: _INSERTED_TIMESTAMP
-        description: "{{ doc('_inserted_timestamp') }}"
-        data_tests:
-          - dbt_expectations.expect_column_to_exist 
-          - not_null
       - name: FACT_EVENTS_INNER_ID
         description: '{{ doc("pk") }}'
         data_tests:

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -29,7 +29,7 @@ models:
         data_tests:
           - dbt_expectations.expect_column_to_exist
           - not_null: *recent_date_filter
-          - unique
+          - unique: *recent_date_filter
       - name: INDEX
         description: "{{ doc('tx_index') }}"
         data_tests:

--- a/models/gold/core/core__fact_transfers.yml
+++ b/models/gold/core/core__fact_transfers.yml
@@ -11,7 +11,7 @@ models:
             - TX_ID
             - INDEX
             - INNER_INDEX
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
@@ -83,7 +83,6 @@ models:
         description: '{{ doc("pk") }}'
         data_tests: 
           - not_null: *recent_date_filter
-          - unique
       - name: INSERTED_TIMESTAMP
         description: '{{ doc("inserted_timestamp") }}'   
         data_tests: 

--- a/models/gold/defi/defi__fact_token_burn_actions.yml
+++ b/models/gold/defi/defi__fact_token_burn_actions.yml
@@ -12,7 +12,7 @@ models:
             - INDEX
             - INNER_INDEX
             - MINT
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
@@ -86,7 +86,6 @@ models:
         description: '{{ doc("pk") }}'
         data_tests: 
           - not_null: *recent_date_filter
-          - unique
       - name: INSERTED_TIMESTAMP
         description: '{{ doc("inserted_timestamp") }}'   
         data_tests: 

--- a/models/gold/defi/defi__fact_token_mint_actions.sql.yml
+++ b/models/gold/defi/defi__fact_token_mint_actions.sql.yml
@@ -12,7 +12,7 @@ models:
             - MINT
             - INDEX
             - INNER_INDEX
-          where: block_timestamp::date > current_date - 30
+          where: block_timestamp::date > current_date - 7
     columns:
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"


### PR DESCRIPTION
- remove `unique` column test as the `unique_combination_of_columns` test performs similarly. Update to test last 7 days which we are following in Solana
- keep `unique` test for `blocks` + `transactions` since the pk is made up of those single columns, and update to test for recent values
- remove `_inserted_timestamp` from `events_inner`. Drop it after merge via `ALTER TABLE eclipse.core.fact_events_inner DROP COLUMN _inserted_timestamp;`
