### PR TITLE
add change tracking

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -44,6 +44,15 @@ models:
         materialized: ephemeral
   eclipse_models:
     +pre-hook: '{{ fsc_utils.set_query_tag() }}'
+    gold:
+      +post-hook: >
+        {% if 'exclude_change_tracking' not in config.get('tags') %}
+          {% if config.get('materialized') == 'view' %}
+            ALTER VIEW {{ this }} SET CHANGE_TRACKING = TRUE;
+          {% else %}
+            ALTER TABLE {{ this }} SET CHANGE_TRACKING = TRUE;
+          {% endif %}
+        {% endif %}  
 
 tests:
   +store_failures: true # all tests


### PR DESCRIPTION
Add change_tracking
- Only stats__ez_core_metrics_hourly.sql needs the `exclude_change_tracking` tag (and it already has it), since it contains logic incompatible with change tracking (ie `GROUP BY`, `UNION`, `QUALIFY`, `LEFT JOIN` logic)